### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+services:
+  - docker
+before_script:
+  - docker build -t jdubois/jhipster-docker .
+script:
+  - docker run -d -p 8080:8080 -p 3000:3000 -p 3001:3001 -p 4022:22 -w /home/jhipster/jhipster-sample-app/ --name=jhipster jdubois/jhipster-docker mvn spring-boot:run ; sleep 120
+  - docker logs jhipster
+  - curl --retry 10 --retry-delay 5 -I http://localhost:8080/ | grep "HTTP/1.1 200 OK"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN cd /home/jhipster && \
 RUN cd /home/jhipster/jhipster-sample-app-2.20.0 && npm install
 RUN cd /home && chown -R jhipster:jhipster /home/jhipster
 RUN cd /home/jhipster/jhipster-sample-app-2.20.0 && sudo -u jhipster mvn dependency:go-offline
+RUN ln -s /home/jhipster/jhipster-sample-app-2.20.0 /home/jhipster/jhipster-sample-app
 
 # expose the working directory, the Tomcat port, the BrowserSync ports, the SSHD port, and run SSHD
 VOLUME ["/jhipster"]


### PR DESCRIPTION
Hello,

Travis CI now officially supports Docker, so I closed the other pull request and work on this.

The .travis.yml file :
* build the image from Dockerfile
* run the container from the image and mvn spring-boot:run the jhipster-sample-app
* check the logs
* try to curl

If you are interested about that, you'll have to config your https://travis-ci.org/jhipster/jhipster-docker
and use it on README.md or http://jhipster.github.io/build_status.html :
```
[![Build Status](https://travis-ci.org/jhipster/jhipster-docker.svg?branch=master)](https://travis-ci.org/jhipster/jhipster-docker)
```
