### PR TITLE
Fix iptables error by restarting service docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: required
 services:
   - docker
-before_script:
+before_install:
+  - sudo service docker restart ; sleep 10
+install:
   - docker build -t jdubois/jhipster-docker .
-script:
   - docker run -d -p 8080:8080 -p 3000:3000 -p 3001:3001 -p 4022:22 -w /home/jhipster/jhipster-sample-app/ --name=jhipster jdubois/jhipster-docker mvn spring-boot:run ; sleep 120
+script:
   - docker logs jhipster
   - curl --retry 10 --retry-delay 5 -I http://localhost:8080/ | grep "HTTP/1.1 200 OK"
-


### PR DESCRIPTION
Hello,

I think the docker service with Travis CI doesn't start properly, without the "Chain DOCKER" in iptables.
So, we can't start container with mapping port.

I added `sudo service docker restart ; sleep 10` and made minor change in build lifecyle.
Someone has tested this solution and it seems to fix the problem : https://github.com/travis-ci/travis-ci/issues/4778

