### PR TITLE
Remove sample app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-sudo: required
+os:
+  - linux
 services:
   - docker
-before_install:
-  - sudo service docker restart ; sleep 10
 install:
   - docker build -t jhipster/jhipster .
   - docker run --name jhipster -w /home/jhipster/app -p 8080:8080 -p 3000:3000 -p 3001:3001 -d -t jhipster/jhipster

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,15 @@ services:
 before_install:
   - sudo service docker restart ; sleep 10
 install:
-  - docker build -t jdubois/jhipster-docker .
-  - docker run -d -p 8080:8080 -p 3000:3000 -p 3001:3001 -w /home/jhipster/jhipster-sample-app/ --name=jhipster jdubois/jhipster-docker mvn spring-boot:run ; sleep 360
+  - docker build -t jhipster/jhipster .
+  - docker run --name jhipster -w /home/jhipster/app -p 8080:8080 -p 3000:3000 -p 3001:3001 -d -t jhipster/jhipster
 script:
+  - docker ps
   - docker logs jhipster
-  - curl --retry 10 --retry-delay 5 -I http://localhost:8080/ | grep "HTTP/1.1 200 OK"
+  - chmod -R 777 $TRAVIS_BUILD_DIR/travis
+  - docker cp $TRAVIS_BUILD_DIR/travis/samples/app-default/.yo-rc.json jhipster:/home/jhipster/app/
+  - docker cp $TRAVIS_BUILD_DIR/travis/.config jhipster:/home/jhipster/
+  - docker exec -u jhipster -it jhipster ls -al /home/jhipster /home/jhipster/app /home/jhipster/.config/configstore
+  - docker exec -u jhipster -it jhipster yo jhipster --force --no-insight
+  - docker exec -u jhipster -it jhipster ls -al /home/jhipster/app
+  - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /
 
 # install node.js
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
-RUN apt-get install -y nodejs unzip python g++ build-essential
+RUN apt-get install -y nodejs python g++ build-essential
 
 # install yeoman bower grunt gulp
 RUN npm install -g yo bower grunt-cli gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /
     echo 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' >> /etc/apt/sources.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
     apt-get update && \
-    echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
+    echo oracle-java${JAVA_VERSION}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
     apt-get install -y --force-yes --no-install-recommends oracle-java${JAVA_VERSION}-installer oracle-java${JAVA_VERSION}-set-default
 
 # install node.js
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 RUN apt-get install -y nodejs unzip python g++ build-essential
 
-# install yeoman grunt bower grunt gulp
+# install yeoman bower grunt gulp
 RUN npm install -g yo bower grunt-cli gulp
 
 # install JHipster
@@ -39,18 +39,9 @@ RUN npm install -g generator-jhipster@${JHIPSTER_VERSION}
 # configure the "jhipster" user
 RUN groupadd jhipster && useradd jhipster -s /bin/bash -m -g jhipster -G jhipster && adduser jhipster sudo
 RUN echo 'jhipster:jhipster' |chpasswd
-
-# install the sample app
-RUN cd /home/jhipster && \
-    wget https://github.com/jhipster/jhipster-sample-app/archive/v${JHIPSTER_VERSION}.zip && \
-    unzip v${JHIPSTER_VERSION}.zip && \
-    rm v${JHIPSTER_VERSION}.zip
-RUN cd /home/jhipster/jhipster-sample-app-${JHIPSTER_VERSION} && npm install
-RUN cd /home && chown -R jhipster:jhipster /home/jhipster
-RUN ln -s /home/jhipster/jhipster-sample-app-${JHIPSTER_VERSION} /home/jhipster/jhipster-sample-app
-
-# add banner
+RUN mkdir -p /home/jhipster/app
 ADD banner.txt /home/jhipster/banner.txt
+RUN cd /home && chown -R jhipster:jhipster /home/jhipster
 
 # clean
 RUN apt-get clean && \

--- a/travis/.config/configstore/insight-bower.json
+++ b/travis/.config/configstore/insight-bower.json
@@ -1,0 +1,4 @@
+{
+       "clientId": 123456789098765,
+       "optOut": true
+}

--- a/travis/.config/configstore/insight-generator-jhipster.json
+++ b/travis/.config/configstore/insight-generator-jhipster.json
@@ -1,0 +1,4 @@
+{
+       "clientId": 123456789098765,
+       "optOut": true
+}

--- a/travis/.config/configstore/insight-yo.json
+++ b/travis/.config/configstore/insight-yo.json
@@ -1,0 +1,4 @@
+{
+       "clientId": 123456789098765,
+       "optOut": true
+}

--- a/travis/samples/app-default/.yo-rc.json
+++ b/travis/samples/app-default/.yo-rc.json
@@ -1,0 +1,23 @@
+{
+  "generator-jhipster": {
+    "baseName": "sampleDefault",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "authenticationType": "session",
+    "hibernateCache": "ehcache",
+    "clusteredHttpSession": "no",
+    "websocket": "no",
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": "no",
+    "useSass": false,
+    "buildTool": "maven",
+    "frontendBuilder": "grunt",
+    "enableTranslation": true,
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
+    "testFrameworks": [
+      "gatling"
+    ]
+  }
+}


### PR DESCRIPTION
Fix :
- change ${JAVA_VER} to ${JAVA_VERSION} : https://github.com/jhipster/generator-jhipster/issues/2335

Major changes :
- delete jhipster-sample-app : the image size will be reduced (virtual size: 1,6GB -> 1,1GB / size in docker hub: 800MB -> 600MB)
- change travis build because there is no jhipster-sample-app anymore: the new build will try to generate a new JHipster project
    - add sample .yo-rc.json
    - add some insight files, to avoid false statistics ;)

Why did I remove the jhipster-sample-app ?
This image should be use to "generate" JHipster project and not for "testing" JHipster app.
I propose it to use this new image as base image for future docker samples images, as discussed.
